### PR TITLE
feat: add typings

### DIFF
--- a/__test__/types-test.ts
+++ b/__test__/types-test.ts
@@ -1,0 +1,45 @@
+// This contains sample code which tests the typings. This code does not run, but it is type-checked
+import { RouterStore, syncHistoryWithStore } from '../';
+import { History, Location } from '../';
+
+const browserHistory: History = undefined;
+const routerStore: RouterStore = new RouterStore();
+const history = syncHistoryWithStore(browserHistory, routerStore);
+
+{
+  // browserHistory.unsubscribe(); 
+  history.unsubscribe();
+
+  const unsubscribeFromStore = history.listen(location => console.log(location.pathname));
+  history.push('/test1');
+  unsubscribeFromStore();
+  history.push('/test2');
+}
+
+{
+  const history: History = routerStore.history;
+  history.createHref('location');
+  history.createHref({ pathname: 'path', hash: '#1234' });
+
+  const location: Location = history.getCurrentLocation();
+  history.push('path/to/location');
+  history.push(location);
+  history.replace('path/to/replace');
+  history.replace({
+    pathname: location.pathname,
+    state: location.state,
+    hash: location.hash,
+    key: location.key
+  });
+}
+
+{
+  const { pathname, hash, key, search, state } = routerStore.location;
+  routerStore.push('path/to/location');
+  routerStore.push({ pathname, hash, key, state });
+  routerStore.go(-1);
+  routerStore.goBack();
+  routerStore.goForward();
+  routerStore.replace('path/to/replace');
+  routerStore.replace({ pathname, hash, key, state });
+}

--- a/__test__/types.spec.js
+++ b/__test__/types.spec.js
@@ -1,0 +1,26 @@
+import path from 'path';
+import * as ts from 'typescript';
+
+beforeEach(() => {
+  jasmine.addMatchers({
+    toBeEmpty: () => ({
+      compare: (actual, expected) => ({
+        pass: actual.length === 0,
+        message: 'Expected empty, but found ' + JSON.stringify(actual, null, 2)
+      })
+    })
+  });
+});
+
+describe('types', () => {
+  it('can diagnose types without errors', () => {
+    const files = [path.join(__dirname, '/types-test.ts')];
+    const options = { noEmit: true };
+    const program = ts.createProgram(files, options);
+    const diagnosticErrors = ts.getPreEmitDiagnostics(program)
+      .filter((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error)
+      .map((diagnostic) => diagnostic.messageText);
+
+    expect(diagnosticErrors).toBeEmpty();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "lint": "eslint src __test__",
     "test": "npm run lint && jest",
     "test-watch": "jest --watch",
-    "test-types": "tsc --noEmit __test__/types-test.ts",
     "clean": "rimraf dist -f",
     "build": "cross-env ENV=production webpack --progress --colors && webpack --progress --colors",
     "prepublish": "npm run clean && npm run lint && npm run test && npm run build",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "mobx-react-router",
   "description": "Keep your MobX state in sync with react-router",
   "main": "dist/mobx-react-router.js",
+  "types": "./types.d.ts",
   "scripts": {
     "lint": "eslint src __test__",
     "test": "npm run lint && jest",
     "test-watch": "jest --watch",
+    "test-types": "tsc --noEmit __test__/types-test.ts",
     "clean": "rimraf dist -f",
     "build": "cross-env ENV=production webpack --progress --colors && webpack --progress --colors",
     "prepublish": "npm run clean && npm run lint && npm run test && npm run build",
@@ -62,9 +64,10 @@
     "react-router": "^3.0.0",
     "react-test-renderer": "^15.3.2",
     "rimraf": "^2.5.4",
+    "semantic-release": "^4.3.5",
     "shallowequal": "^0.2.2",
-    "webpack": "^2.1.0-beta.25",
-    "semantic-release": "^4.3.5"
+    "typescript": "^2.1.4",
+    "webpack": "^2.1.0-beta.25"
   },
   "peerDependencies": {
     "mobx": "^2.5.2",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,76 @@
+declare namespace MobxReactRouter {
+
+  export type Action = 'POP' | 'PUSH' | 'REPLACE';
+  export type TransitionHook = (location: Location, callback: (result: any) => void) => any;
+  export type LocationListener = (location: Location) => void;
+  export type UnsubscribeCallback = () => any;
+  export type ListenerLike = (...args: any[]) => any;
+
+  export interface HistoryLike {
+    push(path: any): any;
+    replace(path: any): any;
+    go(n: number): any;
+    goBack(): any;
+    goForward(): any;
+    listen(listener: ListenerLike): UnsubscribeCallback;
+  }
+
+  export interface History {
+    listenBefore(hook: TransitionHook): UnsubscribeCallback;
+    listen(listener: LocationListener): UnsubscribeCallback;
+    transitionTo(location: Location): void;
+    push(path: string): void;
+    push(location: LocationDescriptor): void;
+    replace(path: string): void;
+    replace(location: LocationDescriptor): void;
+    go(n: number): void;
+    goBack(): void;
+    goForward(): void;
+    createKey(): string;
+    createPath(path: string): string;
+    createPath(location: LocationDescriptor): string;
+    createHref(path: string): string;
+    createHref(location: LocationDescriptor): string;
+    createLocation(path: string, action?: Action, key?: string): Location;
+    createLocation(location: LocationDescriptor): Location;
+    getCurrentLocation: () => Location;
+  }
+
+  export type Location = {
+    pathname: string;
+    search: string;
+    action: string;
+    key: string;
+    hash: string
+    state: any;
+    query?: any;
+    basename?: string;
+  };
+
+  export type LocationDescriptor = {
+    pathname?: string;
+    search?: string;
+    action?: string;
+    state?: any;
+    hash?: string;
+    key?: string;
+  };
+
+  export type SynchronizedHistory = History & { unsubscribe?: UnsubscribeCallback };
+
+  export class RouterStore {
+    location: Location;
+    history: SynchronizedHistory;
+    push(path: string): void;
+    push(location: LocationDescriptor): void;
+    replace(path: string): void;
+    replace(location: LocationDescriptor): void;
+    go(n: number): void;
+    goBack(): void;
+    goForward(): void;
+  }
+
+  export function syncHistoryWithStore(history: HistoryLike, store: RouterStore): SynchronizedHistory;
+}
+
+export = MobxReactRouter;


### PR DESCRIPTION
May I add typings?

Since official mobx is written in Typescript, lots of mobx libraries also have built-in typings. (About more information, see [typescript#publishing](http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html
))

I've happily used this library in my project, and I wrote typing that is compatible with [react-router](https://github.com/ReactTraining/react-router) 3.0 and [history](https://github.com/mjackson/history) 3.0.

If needed, I'll write typings for upcoming v4