### PR TITLE
feat: update types to use latest typescript feature

### DIFF
--- a/__test__/types-test.tsx
+++ b/__test__/types-test.tsx
@@ -1,7 +1,6 @@
 // This contains sample code which tests the typings. This code does not run, but it is type-checked
 import { Router } from 'react-router';
-import { History, Location } from 'history';
-import createBrowserHistory from 'history/createBrowserHistory';
+import { History, Location, createBrowserHistory, createMemoryHistory } from 'history';
 import { RouterStore, SynchronizedHistory, syncHistoryWithStore } from '../';
 
 const routerStore: RouterStore = new RouterStore();
@@ -9,14 +8,13 @@ const browserHistory: History = createBrowserHistory();
 const history: SynchronizedHistory = syncHistoryWithStore(browserHistory, routerStore);
 
 {
-  <Router history={history}>
-    {/* routes */}
-  </Router>
-}
-
-{
+  { <Router history={history} /> }
   { <Router history={browserHistory} /> }
   { <Router history={routerStore.history} /> }
+  { <Router history={createMemoryHistory()} /> }
+  { <Router history={createBrowserHistory()} /> }
+  { <Router history={syncHistoryWithStore(createBrowserHistory(), new RouterStore())} /> }
+  { <Router history={syncHistoryWithStore(createMemoryHistory(), new RouterStore())} /> }
 }
 
 {

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for mobx-react-router 4.0
 // Project: https://github.com/alisd23/mobx-react-router
 
-import { LocationDescriptor, History, UnregisterCallback, Location } from 'history';
+import { History, Location, UnregisterCallback } from 'history';
 
 declare namespace MobxReactRouter {
 
@@ -10,16 +10,11 @@ declare namespace MobxReactRouter {
   }
 
   export class RouterStore {
-    location: Location;
-    history: SynchronizedHistory;
-    push(path: string): void;
-    push(location: LocationDescriptor): void;
-    replace(path: string): void;
-    replace(location: LocationDescriptor): void;
-    go(n: number): void;
-    goBack(): void;
-    goForward(): void;
+    history?: SynchronizedHistory;
+    location?: Location;
   }
+
+  export interface RouterStore extends Pick<History, 'push' | 'replace' | 'go' | 'goBack' | 'goForward'> { }
 
   export function syncHistoryWithStore(history: History, store: RouterStore): SynchronizedHistory;
 }


### PR DESCRIPTION
This change makes the methods derived from `history@4` (`push()`,  `replace()`, `go()`, `goBack()`, `goForward()` exactly match the original signature.