### PR TITLE
Add files array to the package.json to only include dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Keep your MobX state in sync with react-router",
   "main": "dist/mobx-react-router.js",
   "types": "./types.d.ts",
+  "files": ["dist"],
   "scripts": {
     "lint": "eslint src __test__",
     "test": "npm run lint && jest",


### PR DESCRIPTION
Thanks for the awesome library! I was using this library and having the .babelrc was confusing the react-native packager. I added the files array to only include the dist folder in the build.