### PR TITLE
fix: universal packaging for node and browser

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,8 @@ module.exports = {
       : 'mobx-react-router.js',
     library: libraryName,
     libraryTarget: 'umd',
-    umdNamedDefine: true
+    umdNamedDefine: true,
+    globalObject: 'this'
   },
   optimization: {
     minimize: shouldMinify


### PR DESCRIPTION
Webpack upgrade broke universal packaging. See https://github.com/webpack/webpack/issues/6525 and https://github.com/webpack/webpack/issues/6522
As current workaround I've added `globalObject: 'this'` to webpack.config

fixes #65 