### PR TITLE
Fix deprecated usage of history package

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm install --save mobx mobx-react react-router
 ```js
 import React from 'react';
 import ReactDOM from 'react-dom';
-import createBrowserHistory from 'history/createBrowserHistory';
+import { createBrowserHistory } from 'history';
 import { Provider } from 'mobx-react';
 import { RouterStore, syncHistoryWithStore } from 'mobx-react-router';
 import { Router } from 'react-router';


### PR DESCRIPTION
The example from README gives the following warning:
```
Warning: Please use `require("history").createBrowserHistory` instead of `require("history/createBrowserHistory")`. Support for the latter will be removed in the next major release.
```