### PR TITLE
chore: replace `npm cli` by `npm install`

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
+      - run: npm install
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_ACCESS_TOKEN}}


### PR DESCRIPTION
There is no package-lock.json in the repo, so we have to replace `npm cli` by `npm install` in the workflow.